### PR TITLE
Eliminate odd newlines from JSON output

### DIFF
--- a/cifssvrtop
+++ b/cifssvrtop
@@ -297,7 +297,7 @@ profile:::tick-1sec
     OPT_clear && !OPT_json ? printf("%s", CLEAR) : 1;
 
     OPT_json ? 
-        printf("{ \"collector\": \"cifssvrtop\", \"time\": \"%Y\", \"timestamp\": %d, \"interval\": %d, \"load\": %d.%02d, \"read_KB_int\": %d, \"write_KB_int\": %d, \n \"clientdata\": [",
+        printf("{ \"collector\": \"cifssvrtop\", \"time\": \"%Y\", \"timestamp\": %d, \"interval\": %d, \"load\": %d.%02d, \"read_KB_int\": %d, \"write_KB_int\": %d, \"clientdata\": [",
             walltimestamp, walltimestamp, INTERVAL, 
             self->load1a, self->load1b, 
             total_read_bw, total_write_bw)
@@ -316,7 +316,7 @@ profile:::tick-1sec
     OPT_top ? trunc(@c_cifsops, TOP) : 1;
 
     OPT_json ?
-        printa("{\"client\": \"%s\", \"CIFSOPS\": %@d, \"reads\": %@d, \"writes\": %@d, \"read_bw\": %@d, \"write_bw\": %@d, \"avg_read_t\": %@d, \"avg_write_t\": %@d, \"aligned_pct\": %@d },\n",
+        printa("{\"client\": \"%s\", \"CIFSOPS\": %@d, \"reads\": %@d, \"writes\": %@d, \"read_bw\": %@d, \"write_bw\": %@d, \"avg_read_t\": %@d, \"avg_write_t\": %@d, \"aligned_pct\": %@d },",
             @c_cifsops, @c_read, @c_write, @read_bw, @write_bw,
             @avgtime_read, @avgtime_write, @avg_aligned)
     :

--- a/iscsisvrtop
+++ b/iscsisvrtop
@@ -272,7 +272,7 @@ profile:::tick-1sec
     OPT_clear && !OPT_json ? printf("%s", CLEAR) : 1;
 
     OPT_json ?
-        printf("{ \"collector\": \"iscsisvrtop\", \"time\": \"%Y\", \"timestamp\": %d, \"interval\": %d, \"load\": %d.%02d, \"read_KB_int\": %d, \"write_KB_int\": %d, \n \"clientdata\": [",
+        printf("{ \"collector\": \"iscsisvrtop\", \"time\": \"%Y\", \"timestamp\": %d, \"interval\": %d, \"load\": %d.%02d, \"read_KB_int\": %d, \"write_KB_int\": %d, \"clientdata\": [",
             walltimestamp, walltimestamp, INTERVAL, 
             self->load1a, self->load1b, 
             total_bytes_read, total_bytes_write)

--- a/nfssvrtop
+++ b/nfssvrtop
@@ -452,7 +452,7 @@ profile:::tick-1sec
 	OPT_clear && !OPT_json ? printf("%s", CLEAR) : 1;
 	
 	OPT_json ? 
-		printf("{ \"collector\": \"nfssvrtop\", \"time\": \"%Y\", \"timestamp\": %d, \"interval\": %d, \"load\": %d.%02d, \"read_KB_int\": %d, \"sync_write_KB_int\": %d, \"async_write_KB_int\": %d,\n \"clientdata\": [",
+		printf("{ \"collector\": \"nfssvrtop\", \"time\": \"%Y\", \"timestamp\": %d, \"interval\": %d, \"load\": %d.%02d, \"read_KB_int\": %d, \"sync_write_KB_int\": %d, \"async_write_KB_int\": %d, \"clientdata\": [",
 			walltimestamp, walltimestamp, INTERVAL, 
 			self->load1a, self->load1b, 
 			total_read_b, total_swrite_b, total_awrite_b)


### PR DESCRIPTION
For programs that read JSON from stdin
it's easier to read JSON string that fits
to one line than JSON that is spread
across multiple lines.
