### PR TITLE
make zilstat Solaris 11.3 compatible

### DIFF
--- a/zilstat
+++ b/zilstat
@@ -1,4 +1,4 @@
-#! /usr/bin/ksh -p
+#!/usr/bin/ksh -p
 # CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
@@ -130,12 +130,29 @@ if [[ "$interval" == "txg" ]]; then
     interval=0
 fi
 
-if dtrace -lvn fbt::zil_lwb_write_start:entry | grep 'args\[0]: zil_writer_t' > /dev/null ; then
-    to_zilog="->zw_zilog"
-else
-    # args[0]: zilog_t
-    to_zilog=""
-fi
+lwb_write_arg0=`dtrace -lvn fbt::zil_lwb_write_start:entry | grep 'args\[0]:'| awk '{ print $2; }'`
+case $lwb_write_arg0 in
+	zil_writer_t )
+		# Solaris 11.2
+     		to_zilog="args[0]->zw_zilog"
+		lwb_idx=1 
+		;;
+	lwb_t )
+		# Solaris 11.3
+     		to_zilog="args[0]->lwb_zilog"
+		lwb_idx=0
+		;;
+	zilog_t )
+	        # Solaris 10
+     		to_zilog="args[1]->lwb_zilog"
+		lwb_idx=1
+		;;
+        * )
+		echo "unknown fbt::zil_lwb_write_start arguments"
+		exit 1
+		;;
+esac
+# fi
 
 ##############################
 # --- Main Program, DTrace ---
@@ -179,16 +196,16 @@ fi
   */
 
 fbt::zil_lwb_write_start:entry
-/OPT_pool == 0 || POOL == args[0]'"$to_zilog"'->zl_dmu_pool->dp_spa->spa_name/
+/OPT_pool == 0 || POOL == '"$to_zilog"'->zl_dmu_pool->dp_spa->spa_name/
 {
-     nused += args[1]->lwb_nused;
-     nused_per_sec += args[1]->lwb_nused;
-     size += args[1]->lwb_sz;
-     size_per_sec += args[1]->lwb_sz;
+     nused += args['"$lwb_idx"']->lwb_nused;
+     nused_per_sec += args['"$lwb_idx"']->lwb_nused;
+     size += args['"$lwb_idx"']->lwb_sz;
+     size_per_sec += args['"$lwb_idx"']->lwb_sz;
      syncops++;
-     args[1]->lwb_sz <= 4096 ? size_4k++ : 1;
-     args[1]->lwb_sz > 4096 && args[1]->lwb_sz < 32768 ? size_4k_32k++ : 1;
-     args[1]->lwb_sz >= 32768 ? size_32k++ : 1;
+     args['"$lwb_idx"']->lwb_sz <= 4096 ? size_4k++ : 1;
+     args['"$lwb_idx"']->lwb_sz > 4096 && args['"$lwb_idx"']->lwb_sz < 32768 ? size_4k_32k++ : 1;
+     args['"$lwb_idx"']->lwb_sz >= 32768 ? size_32k++ : 1;
 }
 
 /*


### PR DESCRIPTION
unfortunately Solaris 11.3 has changed again the fbt::zil_lwb_write_start arguments.
the new version is more flexible about this.
